### PR TITLE
pre_output - error with empty array

### DIFF
--- a/list/field.list.php
+++ b/list/field.list.php
@@ -62,12 +62,16 @@ class Field_list
 	{
 		$input = unserialize($input);
 		$output = array();
-		foreach ($input as $key => $value) {
-			$output[] = array(
-				'key' => $key,
-				'value' => $value,
-				);
-		}
+		if(!empty($output) && is_array($output)):
+			foreach ($input as $key => $value) {
+				$output[] = array(
+					'key' => $key,
+					'value' => $value,
+					);
+			}
+		else:
+			$output = array();	
+		end;
 		return $output;
 	}
 }


### PR DESCRIPTION
Installed module but was getting and error in the "foreach" loop as the array was empty, may have been from data from previous installation of list field type. Suggesting adding a conditional to check $input has data and check if it is actually an array.
